### PR TITLE
Refactor codegen to use octo guidelines for yml

### DIFF
--- a/macros/generate_model_yaml.sql
+++ b/macros/generate_model_yaml.sql
@@ -9,8 +9,32 @@
     {% if include_data_types %}
         {% do model_yaml.append('        data_type: ' ~ codegen.data_type_format_model(column)) %}
     {% endif %}
-    {% do model_yaml.append('        description: "' ~ column_desc_dict.get(column.name | lower,'') ~ '"') %}
-    {% do model_yaml.append('') %}
+    {% do model_yaml.append('        description: |\n          <INSERT DESCRIPTION>' ~ column_desc_dict.get(column.name | lower,'')) %}
+
+    {% if column.fields|length > 0 %}
+        {% for child_column in column.fields %}
+            {% set model_yaml = codegen.generate_column_yaml(child_column, model_yaml, column_desc_dict, include_data_types, parent_column_name=column_name) %}
+        {% endfor %}
+    {% endif %}
+    {% do return(model_yaml) %}
+{% endmacro %}
+
+{% macro generate_pk_yaml(column, model_yaml, column_desc_dict, include_data_types, parent_column_name="") %}
+    {% if parent_column_name %}
+        {% set column_name = parent_column_name ~ "." ~ column.name %}
+    {% else %}
+        {% set column_name = column.name %}
+    {% endif %}
+
+    {% do model_yaml.append('      - name: ' ~ column_name  | lower ) %}
+    {% if include_data_types %}
+        {% do model_yaml.append('        data_type: ' ~ codegen.data_type_format_model(column)) %}
+    {% endif %}
+    {% do model_yaml.append('        description: |\n          Primary key' ~ column_desc_dict.get(column.name | lower,'')) %}
+    {% do model_yaml.append('        tests:') %}
+    {% do model_yaml.append('          - not_null') %}
+    {% do model_yaml.append('          - unique') %}
+
 
     {% if column.fields|length > 0 %}
         {% for child_column in column.fields %}
@@ -33,15 +57,22 @@
     {% else %}
         {% for model in model_names %}
             {% do model_yaml.append('  - name: ' ~ model | lower) %}
-            {% do model_yaml.append('    description: ""') %}
+            {% do model_yaml.append('    description: |\n      <INSERT DESCRIPTION>') %}
             {% do model_yaml.append('    columns:') %}
 
             {% set relation=ref(model) %}
             {%- set columns = adapter.get_columns_in_relation(relation) -%}
+            {% if columns | length == 0 %}
+                {{ exceptions.raise_compiler_error("Could not find models for column in " ~ model ~ ". Run the model in the current schema first and then try again.") }}
+            {% endif %}
             {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
 
             {% for column in columns %}
-                {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types) %}
+                {% if loop.first %}
+                    {% set model_yaml = codegen.generate_pk_yaml(column, model_yaml, column_desc_dict, include_data_types) %}
+                {% else %}
+                    {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict, include_data_types) %}
+                {% endif %}
             {% endfor %}
         {% endfor %}
     {% endif %}

--- a/macros/generate_source.sql
+++ b/macros/generate_source.sql
@@ -46,7 +46,7 @@
 {% for table in tables %}
     {% do sources_yaml.append('      - name: ' ~ table | lower ) %}
     {% if include_descriptions %}
-        {% do sources_yaml.append('        description: ""' ) %}
+        {% do sources_yaml.append('        description: |\n          <INSERT DESCRIPTION>' ) %}
     {% endif %}
     {% if generate_columns %}
     {% do sources_yaml.append('        columns:') %}
@@ -65,10 +65,9 @@
                 {% do sources_yaml.append('            data_type: ' ~ codegen.data_type_format_source(column)) %}
             {% endif %}
             {% if include_descriptions %}
-                {% do sources_yaml.append('            description: ""' ) %}
+                {% do sources_yaml.append('            description: |\n              <INSERT DESCRIPTION>' ) %}
             {% endif %}
         {% endfor %}
-            {% do sources_yaml.append('') %}
 
     {% endif %}
 


### PR DESCRIPTION
Codegen is useful but still needs a fair amount of manual work. This is a first attempt at improving the automation of this in our own fork. 